### PR TITLE
Add loot whisper functionality

### DIFF
--- a/SociallyUndead/Eventhandler.lua
+++ b/SociallyUndead/Eventhandler.lua
@@ -10,6 +10,7 @@ local playerDurabilities = {}
 local itemTrackingTable = {}
 local similarItemIds = {}
 local addonMessagePrefix = "SU"
+local lootWhisper = { toggled = false, zone = nil }
 
 local events = {}
 local addonMessageHandlers = {}
@@ -159,7 +160,10 @@ function addonMessageHandlers:CAN_LOOT(sender, text)
                         11673 -- Ancient Core Hound
                     }
 
-                    if core.hasValue(skinningTargetIds, npcId) then
+                    if lootWhisper.toggled and lootWhisper.zone == GetRealZoneText() then
+                        core.sendWhisperMessage(sender, "Please loot " .. creatureName)
+
+                    elseif core.hasValue(skinningTargetIds, npcId) then
                         core.printColor(sender .. " can loot" .. creatureName)
 
                         if playerIsMasterLooter then
@@ -588,6 +592,21 @@ local function showBuffs()
 end
 
 core.showBuffs = showBuffs
+
+
+local function toggleLootWhisper()
+  lootWhisper.toggled = not lootWhisper.toggled
+  if lootWhisper.toggled then
+    lootWhisper.zone = GetRealZoneText()
+    core.printColor("Loot whispering enabled for zone: " .. lootWhisper.zone)
+  else
+    lootWhisper.zone = nil
+    core.printColor("Loot whispering disabled") 
+  end
+end
+
+core.toggleLootWhisper = toggleLootWhisper
+
 
 local valuedWorldBuffs = {
     "Songflower Serenade",

--- a/SociallyUndead/Main.lua
+++ b/SociallyUndead/Main.lua
@@ -42,7 +42,8 @@ local function printHelp()
         "/su durability -> Displays durability for players in raid",
         "/su ready -> Displays pre-raid attendance check including location and durability",
         "/su buffs -> WIP - Will display all relevant buffs before pull",
-        "/su worldbuffs -> Displays all worldbuffs and total additional dkp"
+        "/su worldbuffs -> Displays all worldbuffs and total additional dkp",
+        "/su whisper -> Automatically whisper raid members that its their turn to loot for your current zone"
     }
 
     if core.isOfficer() then
@@ -72,6 +73,8 @@ local function sociallyundead(command)
         core.showBuffs()
     elseif core.startsWith(command, "worldbuffs") and isOfficer then
         core.showWorldBuffs()
+    elseif core.startsWith(command, "whisper") and isOfficer then
+        core.toggleLootWhisper()
     elseif core.startsWith(command, "check") then
         checkItem(string.sub(command, 7)) -- TODO: decouple this jank from command word length
     else


### PR DESCRIPTION
CLI allows user to input '/su whisper', toggling loot whispering. This whispers all raid members to loot their mob if in the assigned zone. 