### PR TITLE
Allow non lootmaster to loot whisper

### DIFF
--- a/SociallyUndead/Eventhandler.lua
+++ b/SociallyUndead/Eventhandler.lua
@@ -144,7 +144,7 @@ function addonMessageHandlers:CAN_LOOT(sender, text)
             function()
                 local creatureName, creatureGuid = splitByDelimiter(text, messageDelimiter)
                 local _, mlPlayerId = GetLootMethod()
-                if core.isEmpty(mlPlayerId) or core.isEmpty(creatureGuid) then
+                if (core.isEmpty(mlPlayerId) and not lootWhisper.toggled) or core.isEmpty(creatureGuid) then
                     return
                 end
                 local playerIsMasterLooter = mlPlayerId == 0


### PR DESCRIPTION
Prior to change, loot whisper only worked if you were the loot-master or in the same party as the loot-master. Any officer now has the ability to use loot whispering. 