### PR TITLE
update carapace of the old god rogue prio

### DIFF
--- a/SociallyUndead/generated/GeneratedLoot.lua
+++ b/SociallyUndead/generated/GeneratedLoot.lua
@@ -470,7 +470,7 @@ core.lootDb = {
 	[23558]={["name"]="The Burrower's Shell",["dkp"]="5",["role"]="MS > OS",["note"]=""},
 	[23570]={["name"]="Jom Gabbar",["dkp"]="120",["role"]="Fury-Warrior = Rogue = Enhance-Shaman = Hunter",["note"]=""},
 	[21221]={["name"]="Eye of C'Thun",["dkp"]="60",["role"]="Mage = Warlock = Healer > Warrior = Rogue = Hunter",["note"]=""},
-	[20929]={["name"]="Carapace of the Old God",["dkp"]="60",["role"]="Warrior > Resto-Shaman",["note"]=""},
+	[20929]={["name"]="Carapace of the Old God",["dkp"]="60",["role"]="Warrior = Rogue > Resto-Shaman",["note"]=""},
 	[20933]={["name"]="Husk of the Old God",["dkp"]="60",["role"]="Mage = Warlock",["note"]=""},
 	[21126]={["name"]="Death's Sting",["dkp"]="120",["role"]="Rogue > Warrior",["note"]=""},
 	[21134]={["name"]="Dark Edge of Insanity",["dkp"]="120",["role"]="Enhance-Shaman > Warrior",["note"]=""},

--- a/aq_loot.json
+++ b/aq_loot.json
@@ -569,7 +569,7 @@
   {
     "id": "20929",
     "name": "Carapace of the Old God",
-    "role": "Warrior > Resto-Shaman",
+    "role": "Warrior = Rogue > Resto-Shaman",
     "dkp": 60
   },
   {


### PR DESCRIPTION
Rogues now have equal prio as Warriors for the Carapace of the Old God.